### PR TITLE
Add base types and expressions

### DIFF
--- a/lib/cbr_fp/fusion.ml
+++ b/lib/cbr_fp/fusion.ml
@@ -16,7 +16,7 @@ let rec pull_out_cases : exp -> exp = function
                 inner_branches )
       | outer_scrutinee' -> EMatch (outer_scrutinee', outer_branches'))
   | ECtor (ctor_name, args) -> ECtor (ctor_name, List.map ~f:pull_out_cases args)
-  | EInt n -> EInt n
+  | EBase b -> EBase b
   | EHole (name, typ) -> EHole (name, typ)
   | ERScheme (RListFoldr (b, f)) ->
       ERScheme (RListFoldr (pull_out_cases b, pull_out_cases f))
@@ -66,7 +66,7 @@ let rec fuse' : datatype_env -> typ_env -> exp -> exp =
         , Exp.map_branches branches ~f:(fuse' sigma gamma) )
   | ECtor (ctor_name, args) ->
       ECtor (ctor_name, List.map ~f:(fuse' sigma gamma) args)
-  | EInt n -> EInt n
+  | EBase b -> EBase b
   | EHole (name, typ) -> EHole (name, typ)
   | ERScheme (RListFoldr (b, f)) ->
       ERScheme (RListFoldr (fuse' sigma gamma b, fuse' sigma gamma f))

--- a/lib/cbr_fp/lang.ml
+++ b/lib/cbr_fp/lang.ml
@@ -9,9 +9,15 @@ open Core
 (** Identifiers *)
 type id = string
 
+(** Base types *)
+and base_typ =
+  | BTInt
+  | BTString
+  | BTFloat
+
 (** Types *)
 and typ =
-  | TInt
+  | TBase of base_typ
   | TVar of string
   | TDatatype of string * typ list
   | TArr of typ * typ
@@ -33,6 +39,12 @@ type branch = string * (id list * exp)
 (** Recursion schemes *)
 and rscheme = RListFoldr of exp * exp
 
+(** Base expressions *)
+and base_exp =
+  | BEInt of int
+  | BEString of string
+  | BEFloat of float
+
 (** Expressions *)
 and exp =
   | EVar of id
@@ -40,7 +52,7 @@ and exp =
   | EAbs of id * typ * exp
   | EMatch of exp * branch list
   | ECtor of string * exp list
-  | EInt of int
+  | EBase of base_exp
   | EHole of string * typ
   | ERScheme of rscheme
 [@@deriving sexp, ord, eq, compare, show]

--- a/lib/cbr_fp/parse.ml
+++ b/lib/cbr_fp/parse.ml
@@ -12,7 +12,9 @@ let is_variable : string -> bool = fun s -> Char.is_lowercase (String.get s 0)
 let rec typ_of_sexp : Sexp.t -> typ =
  fun s ->
   match s with
-  | Sexp.Atom "Int" -> TInt
+  | Sexp.Atom "Int" -> TBase BTInt
+  | Sexp.Atom "Float" -> TBase BTFloat
+  | Sexp.Atom "String" -> TBase BTString
   | Sexp.Atom x when is_type_var x -> TVar x
   | Sexp.List [ domain; Sexp.Atom "->"; range ] ->
       TArr (typ_of_sexp domain, typ_of_sexp range)
@@ -38,7 +40,7 @@ let rec branch_of_sexp : Sexp.t -> branch =
 
 and exp_of_sexp : Sexp.t -> exp = function
   | Sexp.Atom x ->
-      (try EInt (Int.of_string x) with
+      (try EBase (BEInt (Int.of_string x)) with
       | _ ->
           if is_variable x
           then EVar x

--- a/lib/cbr_fp/typ.ml
+++ b/lib/cbr_fp/typ.ml
@@ -12,7 +12,9 @@ include T
 include Comparator.Make (T)
 
 let rec show : typ -> string = function
-  | TInt -> "Int"
+  | TBase BTInt -> "Int"
+  | TBase BTFloat -> "Float"
+  | TBase BTString -> "String"
   | TVar x -> x
   | TDatatype (x, taus) ->
       sprintf
@@ -23,7 +25,7 @@ let rec show : typ -> string = function
       sprintf "(%s -> %s)" (show domain) (show codomain)
 
 let rec decompose_arr : typ -> typ list * typ = function
-  | TInt -> ([], TInt)
+  | TBase b -> ([], TBase b)
   | TVar x -> ([], TVar x)
   | TDatatype (x, taus) -> ([], TDatatype (x, taus))
   | TArr (domain, codomain) ->

--- a/lib/cbr_fp/unification_adapter.ml
+++ b/lib/cbr_fp/unification_adapter.ml
@@ -5,7 +5,7 @@ open Unification
 (* Types *)
 
 let rec to_unification_typ : Lang.typ -> Unification.typ = function
-  | TInt -> Elementary TInt
+  | TBase b -> Elementary (TBase b)
   | TVar x -> Elementary (TVar x)
   | TDatatype (x, taus) -> Elementary (TDatatype (x, taus))
   | TArr (domain, codomain) ->
@@ -79,7 +79,9 @@ and to_unification_term'
       in
       embed' "match" "" (scrutinee :: arguments)
   | ECtor (tag, args) -> embed' "ctor" tag args
-  | EInt n -> embed' "int" (Int.to_string n) []
+  | EBase (BEInt n) -> embed' "base_int" (Int.to_string n) []
+  | EBase (BEFloat f) -> embed' "base_float" (Float.to_string f) []
+  | EBase (BEString s) -> embed' "base_string" s []
   | EHole (name, typ) -> Atom (Variable (name, to_unification_typ typ))
   | ERScheme _ -> failwith "cannot embed unapplied recursion scheme"
 
@@ -127,7 +129,9 @@ let rec from_unification_term
               )
         | Some ("ctor", tag) ->
             ECtor (tag, List.map ~f:(from_unification_term sigma) arguments)
-        | Some ("int", n) -> EInt (Int.of_string n)
+        | Some ("base_int", n) -> EBase (BEInt (Int.of_string n))
+        | Some ("base_float", f) -> EBase (BEFloat (Float.of_string f))
+        | Some ("base_string", s) -> EBase (BEString s)
         | Some ("list_foldr", "") ->
             EApp
               ( ERScheme

--- a/test/test_cbr_fp/test_exp.ml
+++ b/test/test_cbr_fp/test_exp.ml
@@ -5,26 +5,26 @@ open Lang
 let%test_unit "substitute 1" =
   [%test_result: exp]
     ~equal:Exp.alpha_equivalent
-    (Exp.substitute ("x", EVar "y") (EAbs ("x", TInt, EVar "x")))
-    ~expect:(EAbs ("x", TInt, EVar "x"))
+    (Exp.substitute ("x", EVar "y") (EAbs ("x", TBase BTInt, EVar "x")))
+    ~expect:(EAbs ("x", TBase BTInt, EVar "x"))
 
 let%test_unit "substitute 2" =
   [%test_result: exp]
     ~equal:Exp.alpha_equivalent
-    (Exp.substitute ("z", EVar "x") (EAbs ("x", TInt, EVar "z")))
-    ~expect:(EAbs ("__var0", TInt, EVar "x"))
+    (Exp.substitute ("z", EVar "x") (EAbs ("x", TBase BTInt, EVar "z")))
+    ~expect:(EAbs ("__var0", TBase BTInt, EVar "x"))
 
 let%test_unit "substitute 3" =
   [%test_result: exp]
     ~equal:Exp.alpha_equivalent
-    (Exp.substitute ("x", EVar "y") (EAbs ("x", TInt, EVar "x")))
-    ~expect:(EAbs ("x", TInt, EVar "x"))
+    (Exp.substitute ("x", EVar "y") (EAbs ("x", TBase BTInt, EVar "x")))
+    ~expect:(EAbs ("x", TBase BTInt, EVar "x"))
 
 let%test_unit "alpha equivalent 1" =
   [%test_result: exp]
     ~equal:Exp.alpha_equivalent
-    (EAbs ("x", TInt, EVar "x"))
-    ~expect:(EAbs ("y", TInt, EVar "y"))
+    (EAbs ("x", TBase BTInt, EVar "x"))
+    ~expect:(EAbs ("y", TBase BTInt, EVar "y"))
 
 let%test_unit "normalizes cases 1" =
   [%test_eq: exp]

--- a/test/test_cbr_fp/test_parse.ml
+++ b/test/test_cbr_fp/test_parse.ml
@@ -89,11 +89,11 @@ let%test_unit "parse program 1 (env)" =
 let%test_unit "parse with ints 1" =
   [%test_result: exp]
     (Parse.exp "(succ -4)")
-    ~expect:(EApp (EVar "succ", EInt (-4)))
+    ~expect:(EApp (EVar "succ", EBase (BEInt (-4))))
 
 let%test_unit "parse with ints 2" =
   [%test_result: exp]
     (Parse.exp "(add 1 -3)")
-    ~expect:(EApp (EApp (EVar "add", EInt 1), EInt (-3)))
+    ~expect:(EApp (EApp (EVar "add", EBase (BEInt 1)), EBase (BEInt (-3))))
 
 let%test_unit "list1 parses" = ignore (Common.parse_file "programs/list1.lisp")


### PR DESCRIPTION
This PR adds base types and expressions as shared variants, making it easier to extend the base set in the future if necessary. This PR implements #31.