### PR TITLE
extraction from database for elm programs

### DIFF
--- a/lib/cbr_fp/extract.py
+++ b/lib/cbr_fp/extract.py
@@ -1,0 +1,42 @@
+import subprocess
+import json
+def load_dataset(n):
+    # Run the Python program and capture its output
+    python_process = subprocess.Popen(['python', 'load.py', str(n)], stdout=subprocess.PIPE)
+
+    # Get the output from the Python program
+    python_output = python_process.communicate()[0].decode('utf-8').strip()
+
+    # Split the string into lines and exclude the first two lines
+    lines = python_output.splitlines()[2:]
+
+    # Join the remaining lines back into a string
+    python_output = '\n'.join(lines)
+
+    # Run the command and pass the Python output as input
+    command = 'elm-format --stdin --json'
+    shell_process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
+    shell_output, _ = shell_process.communicate(input=python_output.encode('utf-8'))
+    shell_output = shell_output.decode('utf-8').strip()
+    data_dict = json.loads(shell_output)
+    return data_dict
+
+text = ""
+for i in range(20):
+    data_dict = load_dataset(i)
+    body = data_dict['body']
+    for block in body:
+        if block.get('tag') == 'Definition' and block['expression']['tag'] == 'CaseExpression':
+            if block['expression']['subject']['tag'] == 'VariableReference':
+                v = block['expression']['subject']['name']
+                for param in block['parameters']:
+                    type = param['type']
+                    pat = param['pattern']
+                    if pat.get('name') == v:
+                        if type['tag'] == 'TypeReference':
+                            if type['name'] == 'Maybe' or type['name'] == 'Result' or type['name'] == 'List':
+                                text += str(block)
+                                text += '\n'
+
+with open("examples.txt", "w") as file:
+    file.write(text)

--- a/lib/cbr_fp/load-from-database.py
+++ b/lib/cbr_fp/load-from-database.py
@@ -1,0 +1,5 @@
+from huggingface_hub import login, hf_hub_download, try_to_load_from_cache
+
+token="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"
+login(token)
+hf_hub_download(repo_id="bigcode/the-stack-dedup", filename="data/elm/data-00000-of-00001.parquet", repo_type="dataset")

--- a/lib/cbr_fp/load.py
+++ b/lib/cbr_fp/load.py
@@ -1,0 +1,10 @@
+from datasets import load_dataset
+import sys
+data = load_dataset("parquet", data_files=[r"\Users\kevin\.cache\huggingface\hub\datasets--bigcode--the-stack-dedup\snapshots\1d5c2bd9e6a7b7407332f0e004c2f4b22e7e9358\data\elm\data-00000-of-00001.parquet"], split="train[:20]")
+
+def main():
+    args = sys.argv[1:]
+    print(data[int(args[0])]['content'])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
loads elm programs from database, and extracts JSON data of functions that we are looking for, namely those whose bodies are a `case` statement on a single parameter, that has type `Maybe`, `Result`, or `List`.

run `load-from-database.py` once to load data from database to cache

then running `extract.py` saves examples to a text file

currently set to only look at first 20 programs in database, but can be changed