### PR TITLE
Revert requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-tensorflow-cloud==0.1.12
+datasets==2.12.0
+huggingface_hub==0.14.1
+nbformat==5.1.3
+numpy==1.22.2
+setuptools==58.1.0


### PR DESCRIPTION
Small fix to `requirements.txt`. Looks like in the process of benchmarking, this file actually got overwritten by some of the database code the script was executing (a great example of why we shouldn't execute arbitrary code from the internet)