### PR TITLE
Fix typo in ARTIFACT_EVALUATION

### DIFF
--- a/ARTIFACT_EVALUATION.md
+++ b/ARTIFACT_EVALUATION.md
@@ -42,7 +42,7 @@ from the root of the repository unless otherwise stated):
 - `cat examples/FilterMapConcat.elm | ./cobbler refactor --language=elm`
 - `cat examples/MapFilter.elm | ./cobbler refactor --language=elm`
 - `cat examples/dot_product.py | ./cobbler refactor --language=python`
-- `cat examples/rolling_sum.elm | ./cobbler refactor --language=python`
+- `cat examples/rolling_sum.py | ./cobbler refactor --language=python`
 
 Note that, in Elm, `x |> f` is equivalent to `f x` (function application).
 


### PR DESCRIPTION
There was a typo in the filename `rolloing_sum.py`:
```
- `cat examples/rolling_sum.elm | ./cobbler refactor --language=python`
```
to
```
- `cat examples/rolling_sum.py | ./cobbler refactor --language=python`
```